### PR TITLE
Location of cat binary has changed on OS X and fixed a JS compile bug.

### DIFF
--- a/Compilers/JavascriptCompiler.php
+++ b/Compilers/JavascriptCompiler.php
@@ -6,7 +6,7 @@ class JavascriptCompiler extends Compiler {
 
 	public function getCompileProcess($path, $context = null) {
 		$uglify = $this->autoMinify ? ' | uglifyjs --compress drop_console=true' : '';
-		return new Process('cat ' . $path . $uglify);
+		return new Process('cat ' . escapeshellarg($path) . $uglify);
 	}
 
 	public function getLastModified($file, $newest = 0) {

--- a/Http/Controller.php
+++ b/Http/Controller.php
@@ -117,8 +117,15 @@ class Controller extends \Illuminate\Routing\Controller {
 			} else {
 				header('X-Cached: false');
 
+				$paths = ['/bin/', '/usr/bin/', '/usr/local/bin/'];
+				foreach($paths as $k => $v) {
+					if(!file_exists($v)) {
+						unset($paths[$k]);
+					}
+				}
+
 				$process->setEnv([
-					'PATH' => trim(`echo \$PATH`) . ':/usr/local/bin/'
+					'PATH' => trim(`echo \$PATH`) . ':' . implode(':', $paths)
 				]);
 
 				$out = '';


### PR DESCRIPTION
No clue when /bin became a thing, but this is handled now. Also added some logic to check for the existence of paths just in case telling shell to look in non-existent paths causes issues for some people.
